### PR TITLE
license: SPDX协议表达式，from:https://spdx.org/licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "keywords": [],
     "author": "Esofar",
-    "license": "TIM",
+    "license": "MIT",
     "bugs": {
         "url": "https://github.com/esofar/cnblogs-theme-silence/issues"
     },


### PR DESCRIPTION
package.json中配置的license表达式应该使用SPDX格式的表达式，根据项目协议MIT，package.json应该把license改为MIT

## more
PR #85 由于我的过失，导致pr内容和commit内容不一致，提交了部分方便调试而添加的cnblogs模版（cnblogs官方提供的页面，可以方便theme开发调试）