### PR TITLE
:lipstick: 体验优化：点击空白处关闭主题弹窗

### DIFF
--- a/src/modules/toolbar/index.js
+++ b/src/modules/toolbar/index.js
@@ -47,6 +47,7 @@ function buildToolbar() {
 
     const $toolbar = $('.esa-toolbar');
     const $skinPopup = $('.skin-popup');
+    var skinPopEl = document.getElementsByClassName('skin-popup')[0];
 
     let show = false;
     $toolbar.find('.bars').click(function () {
@@ -80,15 +81,26 @@ function buildToolbar() {
         $('html').attr('mode', mode);
     });
 
-    $toolbar.find('.skin').click(() => {
+    $toolbar.find('.skin').click((e) => {
+        e.stopPropagation();
         $skinPopup.slideToggle();
     });
 
-    $skinPopup.find('.themes button').click(function () {
-        const theme = $(this).data('theme');
-        sessionStorage.setItem(themeKey, theme);
-        $('html').attr('theme', theme);
-    });
+    skinPopEl.addEventListener('click', function(ev) {
+        ev.stopPropagation()
+        if (ev.target.nodeName === 'BUTTON') {
+            console.log(ev);
+            var theme = ev.target.dataset.theme;
+            sessionStorage.setItem(themeKey, theme);
+            $('html').attr('theme', theme);
+        }
+    })
+
+    document.addEventListener('click', function(ev) {
+        if (skinPopEl && skinPopEl.style.display === 'block') {
+            skinPopEl.style.display = 'none';
+        }
+    })
 
     let showcontents = false;
     $toolbar.find('.contents').click(() => {


### PR DESCRIPTION
主题弹窗打开并设置完后，还只能点击开启按钮才能关闭弹窗，但实际中经常会忘了或者点击控制按钮（三个点），导致页面中只剩下主题弹窗了，这时候还只能重新展开控制按钮，操作关闭。整个过程感觉体验上可以优化下。